### PR TITLE
Fix error Database returning too many rows

### DIFF
--- a/src/Model/LoadInventory.php
+++ b/src/Model/LoadInventory.php
@@ -43,6 +43,9 @@ class LoadInventory implements LoadInventoryInterface
         $rawInventoryByProductId = [];
 
         foreach ($rawInventory as $sku => $productInventory) {
+            if (!key_exists($sku, $productIdBySku)) {
+                continue;
+            }
             $productId = $productIdBySku[$sku];
             $productInventory['product_id'] = $productId;
             unset($productInventory['sku']);


### PR DESCRIPTION
Fix error "Vsbridge Product Indexer indexer process unknown error: Notice: Undefined index: 1270-7862.3 in divante/magento2-vsbridge-indexer-msi/src/Model/LoadInventory.php on line 51" with command "php bin/magento indexer:reindex vsbridge_product_indexer"

Problem with MariaDB, query 
SELECT * FROM `inventory_stock_1` WHERE sku IN ( 1270)
returns also SKU 1270-* values (for example 1270-7861)
![image](https://user-images.githubusercontent.com/20553410/72908453-25d1e200-3d3e-11ea-9873-5f6f572769e4.png)
errors in Magento cron table
![image](https://user-images.githubusercontent.com/20553410/72908537-4863fb00-3d3e-11ea-9ef7-506b96855331.png)
