### PR TITLE
Fixed Undefined index when using this resource model

### DIFF
--- a/src/Model/ResourceModel/Product/Inventory.php
+++ b/src/Model/ResourceModel/Product/Inventory.php
@@ -93,7 +93,7 @@ class Inventory
                     'stock_status' => IndexStructure::IS_SALABLE,
                 ]
             )
-            ->where(IndexStructure::SKU . ' IN (?)', $productIds);
+            ->where(IndexStructure::SKU . ' IN (?)', array_map(function($productId) { return (string)$productId; }, $productIds));
 
         return $connection->fetchAssoc($select);
     }


### PR DESCRIPTION
This will force Zend_Db to quote values into `'` and prevent mysql to try to convert varchar to int.

Closes #6 