### PR TITLE
Include Salable Qty in Stock data

### DIFF
--- a/src/Api/GetStockIdByStoreIdInterface.php
+++ b/src/Api/GetStockIdByStoreIdInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package   Divante\VsbridgeIndexerMsi
+ * @author    Joel Rainwater <joel.rainwater@netatmo.com>
+ * @copyright 2019 Divante Sp. z o.o.
+ * @license   See LICENSE_DIVANTE.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Divante\VsbridgeIndexerMsi\Api;
+
+/**
+ * Service which returns linked stock Id for a store id
+ */
+interface GetStockIdByStoreIdInterface
+{
+    /**
+     * @param int $storeId
+     *
+     * @return int
+     */
+    public function execute(int $storeId): int;
+}

--- a/src/Model/GetStockIdByStoreId.php
+++ b/src/Model/GetStockIdByStoreId.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package   Divante\VsbridgeIndexerMsi
+ * @author    Joel Rainwater <joel.rainwater@netatmo.com>
+ * @copyright 2019 Divante Sp. z o.o.
+ * @license   See LICENSE_DIVANTE.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Divante\VsbridgeIndexerMsi\Model;
+
+use Divante\VsbridgeIndexerMsi\Api\GetStockIdByStoreIdInterface;
+use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Class GetStockIdByStoreId
+ */
+class GetStockIdByStoreId implements GetStockIdByStoreIdInterface
+{
+    /**
+     * @var StockByWebsiteIdResolverInterface
+     */
+    private $stockByWebsiteId;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Construct
+     *
+     * @param StockByWebsiteIdResolverInterface $stockByWebsiteId
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        StockByWebsiteIdResolverInterface $stockByWebsiteId,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->stockByWebsiteId = $stockByWebsiteId;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(int $storeId): int
+    {
+        $websiteId = (int)$this->storeManager->getStore($storeId)->getWebsiteId();
+        $stockId = (int)$this->stockByWebsiteId->execute($websiteId)->getStockId();
+        return $stockId;
+    }
+}

--- a/src/Model/LoadInventory.php
+++ b/src/Model/LoadInventory.php
@@ -15,7 +15,7 @@ use Divante\VsbridgeIndexerMsi\Api\GetStockIdByStoreIdInterface;
 use Divante\VsbridgeIndexerMsi\Model\ResourceModel\Product\Inventory as InventoryResource;
 use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
 use Magento\InventoryConfigurationApi\Model\IsSourceItemManagementAllowedForSkuInterface;
-use Magento\InventoryReservationsApi\Model\GetReservationsQuantityInterface;
+use Magento\InventoryReservations\Model\ResourceModel\GetReservationsQuantity;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
 
 /**
@@ -39,7 +39,7 @@ class LoadInventory implements LoadInventoryInterface
     private $getStockItemConfiguration;
 
     /**
-     * @var GetReservationsQuantityInterface
+     * @var GetReservationsQuantity
      */
     private $getReservationsQuantity;
 
@@ -54,14 +54,14 @@ class LoadInventory implements LoadInventoryInterface
      * @param InventoryResource $resource
      * @param GetStockIdByStoreIdInterface $getStockIdByStoreId
      * @param GetStockItemConfigurationInterface $getStockItemConfig
-     * @param GetReservationsQuantityInterface $getReservationsQuantity
+     * @param GetReservationsQuantity $getReservationsQuantity
      * @param IsSourceItemManagementAllowedForSkuInterface $isSourceItemManagementAllowedForSku
      */
     public function __construct(
         InventoryResource $resource,
         GetStockIdByStoreIdInterface $getStockIdByStoreId,
         GetStockItemConfigurationInterface $getStockItemConfig,
-        GetReservationsQuantityInterface $getReservationsQuantity,
+        GetReservationsQuantity $getReservationsQuantity,
         IsSourceItemManagementAllowedForSkuInterface $isSourceItemManagementAllowedForSku
     ) {
         $this->resource = $resource;

--- a/src/Plugin/Api/PlaceReservationsForSalesEventPlugin.php
+++ b/src/Plugin/Api/PlaceReservationsForSalesEventPlugin.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/**
+ * @package Divante\VsbridgeIndexerMsi
+ * @author Joel Rainwater <joel.rainwater@netatmo.com>
+ * @copyright 2019 Divante Sp. z o.o.
+ * @license See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Divante\VsbridgeIndexerMsi\Plugin\Api;
+
+use Divante\VsbridgeIndexerCatalog\Model\Indexer\Product as ProductIndexer;
+use Magento\Catalog\Model\ProductIdLocatorInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+
+/**
+ * Class PlaceReservationsForSalesEventPlugin
+ */
+class PlaceReservationsForSalesEventPlugin
+{
+    /**
+     * @var ProductIndexer
+     */
+    private $indexer;
+
+    /**
+     * @var ProductIdLocatorInterface
+     */
+    private $productIdLocator;
+
+    /**
+     * PlaceReservationsForSalesEventPlugin constructor.
+     *
+     * @param ProductIndexer $indexer
+     * @param ProductIdLocatorInterface $productIdLocator
+     */
+    public function __construct(ProductIndexer $indexer, ProductIdLocatorInterface $productIdLocator)
+    {
+        $this->indexer = $indexer;
+        $this->productIdLocator = $productIdLocator;
+    }
+
+    /**
+     * Around Execute so we have access to $items
+     *
+     * @param PlaceReservationsForSalesEventInterface $subject
+     * @param callable $proceed
+     * @param array $items
+     * @param SalesChannelInterface $salesChannel
+     * @param SalesEventInterface $salesEvent
+     *
+     * @return void
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     */
+    public function aroundExecute(
+        PlaceReservationsForSalesEventInterface $subject,
+        callable $proceed,
+        array $items,
+        SalesChannelInterface $salesChannel,
+        SalesEventInterface $salesEvent
+    ) {
+        // continue with execution
+        $proceed($items, $salesChannel, $salesEvent);
+
+        // we have to get product ids from skus
+        $skus = [];
+        /** @var \Magento\InventorySalesApi\Api\Data\ItemToSellInterface $item */
+        foreach ($items as $item) {
+            $skus[] = $item->getSku();
+        }
+        $productIds = [];
+        foreach ($this->productIdLocator->retrieveProductIdsBySkus($skus) as $idsBySku) {
+            array_push($productIds, ...array_keys($idsBySku));
+        }
+
+        // reindex after reservation has been placed
+        $this->indexer->executeList($productIds);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -3,6 +3,9 @@
     <type name="Magento\InventoryCatalog\Model\SourceItemsSaveSynchronization\SetDataToLegacyCatalogInventory">
         <plugin name="updateProductsInEs" type="Divante\VsbridgeIndexerMsi\Plugin\InventoryCatalog\SetDataToLegacyCatalogInventoryPlugin"/>
     </type>
+    <type name="Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface">
+        <plugin name="updateProductsInEs" type="Divante\VsbridgeIndexerMsi\Plugin\Api\PlaceReservationsForSalesEventPlugin"/>
+    </type>
 
     <preference for="Divante\VsbridgeIndexerMsi\Api\GetStockIdBySalesChannelCodeInterface" type="Divante\VsbridgeIndexerMsi\Model\GetStockIdBySalesChannelCode"/>
     <preference for="Divante\VsbridgeIndexerMsi\Api\GetStockIdByStoreIdInterface" type="Divante\VsbridgeIndexerMsi\Model\GetStockIdByStoreId"/>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -5,6 +5,7 @@
     </type>
 
     <preference for="Divante\VsbridgeIndexerMsi\Api\GetStockIdBySalesChannelCodeInterface" type="Divante\VsbridgeIndexerMsi\Model\GetStockIdBySalesChannelCode"/>
+    <preference for="Divante\VsbridgeIndexerMsi\Api\GetStockIdByStoreIdInterface" type="Divante\VsbridgeIndexerMsi\Model\GetStockIdByStoreId"/>
     <preference for="Divante\VsbridgeIndexerCatalog\Api\LoadInventoryInterface" type="Divante\VsbridgeIndexerMsi\Model\LoadInventory"/>
 
     <type name="Divante\VsbridgeIndexerCatalog\Model\Indexer\DataProvider\Product\ConfigurableData">


### PR DESCRIPTION
No issue opened for this feature, but was lightly discussed here - https://forum.vuestorefront.io/t/support-for-inventory-reservations-from-magento-2-3/469/

This includes the calculated value of Available Qty, which is what Magento uses to determine if a product can be purchased/added to cart. It is calculated by taking the current QTY, subtracting all reservations (created when an order is placed), and the minimum allowed QTY of the product.

This should probably be tested in other environments. I only was able to test it in a Magento environment where we do NOT utilize the Multi-Source Inventory capabilities (only have a single source), and only some of our products have Manage Stock enabled.

One piece that I had a little trouble with, and I'm open to suggestions if there's a better solution, is updating the available qty whenever a Reservation is created. When an order is placed, Magento creates a Reservation for that product. This was not triggering a reindex. I wanted to add a subscription to the `inventory_reservation` table, but the product identifier is the SKU, and not the Product Id, so a subscription in `mview` wouldn't work. Instead I created a plugin to listen to the Reservation being created, but I'm not sure that this is the best solution.

Let me know if you have questions/concerns about this pull request!